### PR TITLE
Fixed a few bugs with resolving claims.

### DIFF
--- a/apigee/adapter.go
+++ b/apigee/adapter.go
@@ -405,7 +405,8 @@ func resolveClaims(log adapter.Logger, claimsIn map[string]string) map[string]in
 		}
 
 		if len(encoded)%4 != 0 {
-			// Weird base64 bug, need to pad with =.
+			// Encoded base64 must always have a length divisble by 4, or DecodeString
+			// will fail. Pad with "=" to make it happy.
 			encoded += strings.Repeat("=", 4-(len(encoded)%4))
 		}
 		decoded, err := base64.StdEncoding.DecodeString(encoded)

--- a/apigee/adapter.go
+++ b/apigee/adapter.go
@@ -391,7 +391,7 @@ func (h *handler) HandleQuota(ctx context.Context, inst *quotaT.Instance, args a
 func resolveClaims(log adapter.Logger, claimsIn map[string]string) map[string]interface{} {
 	var claims = map[string]interface{}{}
 	for _, k := range auth.AllValidClaims {
-		if v, ok := claims[k]; ok {
+		if v, ok := claimsIn[k]; ok {
 			claims[k] = v
 		}
 	}
@@ -399,19 +399,16 @@ func resolveClaims(log adapter.Logger, claimsIn map[string]string) map[string]in
 		return claims
 	}
 
-	var err error
 	if encoded, ok := claimsIn[encodedClaimsKey]; ok {
 		if encoded == "" {
 			return claims
 		}
-		var decoded []byte
-		decoded, err = base64.StdEncoding.DecodeString(encoded)
 
-		// hack: weird truncation issue coming from Istio, add suffix and try again
-		if err != nil && strings.HasPrefix(err.Error(), "illegal base64 data") {
-			decoded, err = base64.StdEncoding.DecodeString(encoded + "o=")
+		if len(encoded)%4 != 0 {
+			// Weird base64 bug, need to pad with =.
+			encoded += strings.Repeat("=", 4-(len(encoded)%4))
 		}
-
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
 		if err == nil {
 			err = json.Unmarshal(decoded, &claims)
 		}

--- a/apigee/adapter_test.go
+++ b/apigee/adapter_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"strconv"
@@ -179,7 +180,7 @@ func TestResolveClaims(t *testing.T) {
 
 	want := map[string]string{}
 	for i, c := range auth.AllValidClaims {
-		input[c] = strconv.Itoa(i)
+		want[c] = strconv.Itoa(i)
 	}
 
 	jsonBytes, err := json.Marshal(want)
@@ -195,6 +196,12 @@ func TestResolveClaims(t *testing.T) {
 		{"map of strings", want},
 		{"encoded value", map[string]string{
 			encodedClaimsKey: encoded,
+		}},
+		{"encoded with invalid padding", map[string]string{
+			// This is a bug from production: edgemicro returns strings that are not
+			// padded with =, so the decode fails. Our encoded version is padded
+			// properly, strip off the = so that it is no longer valid.
+			encodedClaimsKey: strings.Replace(encoded, "=", "", -1),
 		}},
 	} {
 		t.Log(ea.desc)


### PR DESCRIPTION
A few issues going on here:
* `claims` in `resolveClaims` was always empty, so it never worked unless claims were encoded
* some real-world input does not pad with "=", so decoding fails
* `want` value in test was not getting set, so tests always passed regardless of input value