### PR TITLE
Issue74: Fix invalid gzip files uploaded to analytics

### DIFF
--- a/adapter/analytics/analytics_test.go
+++ b/adapter/analytics/analytics_test.go
@@ -498,7 +498,7 @@ func TestValidationFailure(t *testing.T) {
 	}
 }
 
-func TestCrashRecovery(t *testing.T) {
+func TestCrashRecoveryInvalidFiles(t *testing.T) {
 	t.Parallel()
 
 	fs := newFakeServer(t)
@@ -562,6 +562,110 @@ func TestCrashRecovery(t *testing.T) {
 	json.NewEncoder(gz).Encode(&rec)
 	// Close the file, but don't close the gzip to ensure it's broken.
 	gz.Flush()
+	f.Close()
+
+	// Now attempt recovery.
+	if err := m.crashRecovery(); err != nil {
+		t.Fatal(err)
+	}
+
+	// We should have two proper gzip files in the staging dir.
+	files, err := ioutil.ReadDir(targetBucket)
+	if err != nil {
+		t.Fatalf("ls %s: %s", targetBucket, err)
+	}
+
+	if len(files) != 1 {
+		t.Errorf("got %d files in staging, want 1:", len(files))
+		for _, fi := range files {
+			t.Log(fi.Name())
+		}
+	}
+	for _, fi := range files {
+		// Confirm that it's a valid gzip file.
+		f, err := os.Open(path.Join(targetBucket, fi.Name()))
+		if err != nil {
+			t.Fatalf("error opening %s: %s", fi.Name(), err)
+		}
+		gz, err := gzip.NewReader(f)
+		if err != nil {
+			t.Errorf("gzip error %s: %s", fi.Name(), err)
+		}
+		var got Record
+		if err := json.NewDecoder(gz).Decode(&got); err != nil {
+			t.Errorf("json decode error %s: %s", fi.Name(), err)
+		}
+
+		if got != rec {
+			t.Errorf("file %s: got %v, want %v", fi.Name(), got, rec)
+		}
+	}
+}
+
+func TestCrashRecoveryGoodFiles(t *testing.T) {
+	t.Parallel()
+
+	fs := newFakeServer(t)
+	defer fs.Close()
+
+	d, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("ioutil.TempDir(): %s", err)
+	}
+	defer os.RemoveAll(d)
+	baseURL, _ := url.Parse(fs.URL())
+	m, err := newManager(Options{
+		BufferPath: d,
+		BufferSize: 10,
+		BaseURL:    *baseURL,
+		Key:        "key",
+		Secret:     "secret",
+	})
+	if err != nil {
+		t.Fatalf("newManager: %s", err)
+	}
+	// Set logger so we can log things while debugging.
+	env := adaptertest.NewEnv(t)
+	m.log = env.Logger()
+
+	// Put two files into the temp dir:
+	// - a good gzip file
+	// - a corrupted gzip file
+	ts := int64(1521221450) // This timestamp is roughly 11:30 MST on Mar. 16, 2018.
+	rec := Record{
+		Organization:                 "hi",
+		Environment:                  "test",
+		ClientReceivedStartTimestamp: ts * 1000,
+		ClientReceivedEndTimestamp:   ts * 1000,
+	}
+
+	bucket := path.Join(m.tempDir, "hi~test")
+	targetBucket := path.Join(m.stagingDir, "hi~test")
+	if err := os.MkdirAll(bucket, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(targetBucket, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	goodFile := path.Join(bucket, "good.json.gz")
+	brokeFile := path.Join(bucket, "broke.json.gz")
+
+	f, err := os.Create(goodFile)
+	if err != nil {
+		t.Fatalf("error creating good file: %s", err)
+	}
+	gz := gzip.NewWriter(f)
+	json.NewEncoder(gz).Encode(&rec)
+	gz.Flush()
+	gz.Close()
+	f.Close()
+
+	f, _ = os.Create(brokeFile)
+	gz = gzip.NewWriter(f)
+	json.NewEncoder(gz).Encode(&rec)
+	gz.Flush()
+	gz.Close()
 	f.Close()
 
 	// Now attempt recovery.


### PR DESCRIPTION
Fix invalid gzip files getting uploaded to analytics by the analytics adapter.

Problem
=======
There are two root causes for this problem.
1. The gzip writer stream should be closed after a flush so that it writes
   the metadata to the zip. This was not happening in certain cases.
2. In crashRecovery method in the analytics adapter, there is no validation
   in place to check if the gzip is a valid gzip or not.

Fix
===
1. Close() the writer stream after the Flush().
2. Fix the crashRecovery logic to skip the invalid gzip files.
3. Add test cases which handles two good zips; fix the existing crashRecovery
   test case.